### PR TITLE
Implement ADD A,n instruction for 8-bit ALU

### DIFF
--- a/src/cpu.c
+++ b/src/cpu.c
@@ -165,6 +165,18 @@ void optable_init(void) {
     instr_lookup[0x7D] = OPC_LD_A_L;
     instr_lookup[0x7E] = OPC_LD_A_HL;
     instr_lookup[0x7F] = OPC_LD_A_A;
+
+	// 8-bit ALU: ADD A,n
+	instr_lookup[0x80] = OPC_ADD_A_B;
+	instr_lookup[0x81] = OPC_ADD_A_C;
+	instr_lookup[0x82] = OPC_ADD_A_D;
+	instr_lookup[0x83] = OPC_ADD_A_E;
+	instr_lookup[0x84] = OPC_ADD_A_H;
+	instr_lookup[0x85] = OPC_ADD_A_L;
+	instr_lookup[0x86] = OPC_ADD_A_HL;
+	instr_lookup[0x87] = OPC_ADD_A_A;
+	instr_lookup[0xC6] = OPC_ADD_A_d8;
+
     // TODO: 0xA8
     // TODO: 0xA9
     // TODO: 0xAA

--- a/src/cpu.h
+++ b/src/cpu.h
@@ -138,4 +138,37 @@ void OPC_LD_A_A(void);
 
 uint16_t cpu_get_two_bytes(uint16_t addr);
 
+/******************************************************
+ *** 8-BIT ALU                                      ***
+ ******************************************************/
+
+void OPC_ADD_A_A(void);
+
+void OPC_ADD_A_B(void);
+
+void OPC_ADD_A_C(void);
+
+void OPC_ADD_A_D(void);
+
+void OPC_ADD_A_E(void);
+
+void OPC_ADD_A_H(void);
+
+void OPC_ADD_A_L(void);
+
+/**
+ * @brief First fetches a byte from the address `HL`,
+ * 		  then adds the fetched byte to A.
+ */
+void OPC_ADD_A_HL(void);
+
+/**
+ * @brief First fetches an immediate byte from PC + 1,
+ * 		  then adds the fetched byte to A.
+ *
+ * @warning PC cannot be incremented before this operation is completed
+ * 			since it reads the data from the opcode itself.
+ */
+void OPC_ADD_A_d8(void);
+
 #endif //YOBEMAG_CPU_H


### PR DESCRIPTION
This adds a _preliminary_ implementation of the `ADD A,n` instruction for the gameboy's 8-bit ALU.