### PR TITLE
Add Criterion as unit test suite

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,9 +36,9 @@ jobs:
           curl -sSLo $HOME/.sonar/build-wrapper-linux-x86.zip ${{ env.BUILD_WRAPPER_DOWNLOAD_URL }}
           unzip -o $HOME/.sonar/build-wrapper-linux-x86.zip -d $HOME/.sonar/
           echo "$HOME/.sonar/build-wrapper-linux-x86" >> $GITHUB_PATH
-      - name: Install SDL2
+      - name: Install Dependencies
         run: |
-          sudo apt-get install libsdl2-dev gcc-multilib ninja-build -y
+          sudo apt-get install libsdl2-dev gcc-multilib ninja-build libcriterion-dev -y
       - name: Run build-wrapper
         run: |
           mkdir build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,15 +4,27 @@ project(YOBEMAG C)
 set(PRODUCT_NAME yobemag)
 string(TOUPPER ${PRODUCT_NAME} MSG_PREFIX)
 
+include_directories(src)
+set(SRC_FILES
+    src/cpu.c
+    src/main.c
+    src/mmu.c
+    src/lcd.c
+    src/rom.c)
+
+add_executable(${PRODUCT_NAME} ${SRC_FILES})
+
+add_subdirectory(test)
+
 message("[${MSG_PREFIX}] Using ${CMAKE_GENERATOR}")
 message("[${MSG_PREFIX}] Using ${CMAKE_C_COMPILER}")
 
 if (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "DEBUG" OR CMAKE_BUILD_TYPE STREQUAL "debug")
     message("[${MSG_PREFIX}] Using -g")
-    add_compile_options(-g)
+    target_compile_options(${PRODUCT_NAME} PUBLIC -g)
 endif ()
 
-add_compile_options(
+target_compile_options(${PRODUCT_NAME} PUBLIC
     # Standard GCC/Clang warnings
     -Wall
     -Wextra
@@ -39,17 +51,18 @@ add_compile_options(
     -Wformat=2)
 
 message("[${MSG_PREFIX}] Using -O${OPTIMIZE}")
+# Use the same optimization level for build and test
 add_compile_options(-O${OPTIMIZE})
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
-    add_compile_options(
+    target_compile_options(${PRODUCT_NAME} PUBLIC
         -Weverything
         -Wno-declaration-after-statement
         -Wno-padded
         -Wno-gnu-designator
         -ferror-limit=0)
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID STREQUAL "GNU")
-    add_compile_options(
+    target_compile_options(${PRODUCT_NAME} PUBLIC
         # Standard GCC warnings: https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html
         -Wlogical-op
         -Warray-bounds=2
@@ -66,16 +79,6 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID STREQUAL "GN
         -Wsuggest-attribute=format
         -fmax-errors=0)
 endif ()
-
-include_directories(src)
-set(SRC_FILES
-    src/cpu.c
-    src/main.c
-    src/mmu.c
-    src/lcd.c
-    src/rom.c)
-
-add_executable(${PRODUCT_NAME} ${SRC_FILES})
 
 set_property(TARGET ${PRODUCT_NAME} PROPERTY C_STANDARD 17)
 set(CMAKE_C_STANDARD_REQUIRED ON)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,10 @@
+set(TEST_NAME yobemag_test)
+
+set(TEST_FILES
+    sample_unit_test.c)
+
+add_executable(${TEST_NAME} ${TEST_FILES})
+
+target_link_libraries(${TEST_NAME} PRIVATE -lm -lcriterion)
+
+add_custom_target(test COMMAND ./${TEST_NAME})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,4 +7,4 @@ add_executable(${TEST_NAME} ${TEST_FILES})
 
 target_link_libraries(${TEST_NAME} PRIVATE -lm -lcriterion)
 
-add_custom_target(test COMMAND ./${TEST_NAME})
+add_custom_target(test COMMAND ./${TEST_NAME} DEPENDS ${TEST_NAME})

--- a/test/sample_unit_test.c
+++ b/test/sample_unit_test.c
@@ -1,0 +1,16 @@
+#include <criterion/criterion.h>
+#include <stdio.h>
+
+void setup(void)
+{
+	puts("Runs before the test");
+}
+
+void teardown(void)
+{
+	puts("Runs after the test");
+}
+
+Test(simple, fixtures, .init = setup, .fini = teardown) {
+	cr_assert(1);
+}

--- a/test/sample_unit_test.c
+++ b/test/sample_unit_test.c
@@ -1,13 +1,11 @@
 #include <criterion/criterion.h>
 #include <stdio.h>
 
-void setup(void)
-{
+void setup(void) {
 	puts("Runs before the test");
 }
 
-void teardown(void)
-{
+void teardown(void) {
 	puts("Runs after the test");
 }
 


### PR DESCRIPTION
This addressses #12.
The test suite integrates with CMake by using a custom target `test`.
Use as follows:
```
mkdir build && cd build
cmake -G Ninja -DCMAKE_BUILD_TYPE=debug -DOPTIMIZE=3 -DCMAKE_C_COMPILER=gcc ..
ninja test
```