### PR TITLE
feat: exit program if more than 100 unimplemented opcodes were execed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ message("[${UPPER_PRODUCT_NAME}] Using ${CMAKE_C_COMPILER} ${CMAKE_C_COMPILER_VE
 if (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "DEBUG" OR CMAKE_BUILD_TYPE STREQUAL "debug")
     message("[${UPPER_PRODUCT_NAME}] Using -g")
     target_compile_options(${PRODUCT_NAME} PUBLIC -g)
+    target_compile_definitions(${PRODUCT_NAME} PUBLIC YOBEMAG_DEBUG)
 endif ()
 
 target_compile_options(${PRODUCT_NAME} PUBLIC

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -14,7 +14,17 @@ typedef void (*op_function)(void);
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
 static void UNKNOWN_OPCODE(void) {
+
     LOG_ERROR("Unallowed/Unimplemented OP Code: 0x%x", cpu.opcode);
+
+#if defined(YOBEMAG_DEBUG)
+    static unsigned err_count = 0;
+    if (++err_count > 100) {
+        LOG_FATAL("Exceeded number of unallowed OP codes!");
+        exit(EXIT_FAILURE);
+    }
+#endif // defined(YOBEMAG_DEBUG)
+
 }
 #pragma GCC diagnostic pop
 

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -14,21 +14,23 @@ typedef void (*op_function)(void);
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
 
-static void UNKNOWN_OPCODE(void) {
 #if defined(YOBEMAG_DEBUG)
 
+static void UNKNOWN_OPCODE(void) {
     static unsigned err_count = 0;
     LOG_ERROR("Unallowed/Unimplemented OP Code: 0x%x", cpu.opcode);
     if (++err_count > 100) {
         YOBEMAG_EXIT("Exceeded number of unallowed OP codes!");
     }
+}
 
 #else
 
+_Noreturn static void UNKNOWN_OPCODE(void) {
     YOBEMAG_EXIT("An unsupported instruction was encountered: 0x%x", cpu.opcode);
-
-#endif // defined(YOBEMAG_DEBUG)
 }
+
+#endif // defined(YOBEMAG_EXIT)
 
 #pragma GCC diagnostic pop
 

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -20,14 +20,12 @@ static void UNKNOWN_OPCODE(void) {
     static unsigned err_count = 0;
     LOG_ERROR("Unallowed/Unimplemented OP Code: 0x%x", cpu.opcode);
     if (++err_count > 100) {
-        LOG_FATAL("Exceeded number of unallowed OP codes!");
-        exit(EXIT_FAILURE);
+        YOBEMAG_EXIT("Exceeded number of unallowed OP codes!");
     }
 
 #else
 
-    LOG_FATAL("An unsupported instruction was encountered: 0x%x", cpu.opcode);
-    exit(EXIT_FAILURE);
+    YOBEMAG_EXIT("An unsupported instruction was encountered: 0x%x", cpu.opcode);
 
 #endif // defined(YOBEMAG_DEBUG)
 }

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -13,19 +13,25 @@ typedef void (*op_function)(void);
 // Function is used for instruction array initialization, not recognized by compiler
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
+
 static void UNKNOWN_OPCODE(void) {
-
-    LOG_ERROR("Unallowed/Unimplemented OP Code: 0x%x", cpu.opcode);
-
 #if defined(YOBEMAG_DEBUG)
+
     static unsigned err_count = 0;
+    LOG_ERROR("Unallowed/Unimplemented OP Code: 0x%x", cpu.opcode);
     if (++err_count > 100) {
         LOG_FATAL("Exceeded number of unallowed OP codes!");
         exit(EXIT_FAILURE);
     }
-#endif // defined(YOBEMAG_DEBUG)
 
+#else
+
+    LOG_FATAL("An unsupported instruction was encountered: 0x%x", cpu.opcode);
+    exit(EXIT_FAILURE);
+
+#endif // defined(YOBEMAG_DEBUG)
 }
+
 #pragma GCC diagnostic pop
 
 static op_function instr_lookup[0xFF + 1]       = {[0 ... 0xFF] = UNKNOWN_OPCODE};


### PR DESCRIPTION
Basically all that is to it is in the title.
Defines a `YOBEMAG_DEBUG` variable, should `cmake` be configured to compile in debug mode. 
This is used to compile in a check for the number of encountered unimplemented OP codes and exits, if a certain number of encounters is reached.