### PR TITLE
feat: register teardown function after corresponding subsystem is inited

### DIFF
--- a/src/lcd.c
+++ b/src/lcd.c
@@ -27,6 +27,10 @@ void lcd_init(void) {
     surface = SDL_GetWindowSurface(window);
 }
 
+void lcd_teardown(void) {
+    SDL_Quit();
+}
+
 bool lcd_step(void) {
     SDL_Event e;
     uint8_t const *key_states;

--- a/src/lcd.h
+++ b/src/lcd.h
@@ -6,6 +6,7 @@
 #include <SDL2/SDL.h>
 
 void lcd_init(void);
+void lcd_teardown(void);
 bool lcd_step(void);
 
 #endif // YOBEMAG_LCD_H

--- a/src/log.c
+++ b/src/log.c
@@ -48,6 +48,11 @@ void log_set_lvl(LoggingLevel log_lvl) {
     LOG_INFO("Log level initialized to %d.", min_log_lvl);
 }
 
+void log_teardown(void) {
+    fflush(stderr);
+    fflush(stdout);
+}
+
 void log_exit(char const *const file_path, int const line_number, char const *const msg, ...) {
     va_list args;
     va_start(args, msg);

--- a/src/log.h
+++ b/src/log.h
@@ -19,6 +19,11 @@ typedef enum LoggingLevel {
 void log_set_lvl(LoggingLevel log_lvl);
 
 /**
+ * @brief   Flash stdout and stderr on exit
+ */
+void log_teardown(void);
+
+/**
  * @brief 	Log a string to stderr with logging level ::FATAL formatted as
  * 			@p msg with parameters @p ...
  * 			This function is invoked by `#YOBEMAG_EXIT(msg, ...)`.
@@ -49,15 +54,19 @@ __attribute__((format(printf, 4, 5))) void log_str(LoggingLevel log_lvl, char co
  * This is necessary, since __VA_ARGS__ is a C GNU extension.
  * clang will not compile with -Werror, if this warning is not ignored here.
  * Ignoring is fine, since clang can handle this GNU extension.
+ *
+ * The second ignored diagnostic surpresses "Macro not used" messages.
  */
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
+#pragma clang diagnostic ignored "-Wunused-macros"
 
 #define LOG_DEBUG(msg, ...)    log_str(DEBUG, "DEBUG", stdout, msg, ##__VA_ARGS__)
 #define LOG_INFO(msg, ...)     log_str(INFO, "INFO", stdout, msg, ##__VA_ARGS__)
 #define LOG_WARNING(msg, ...)  log_str(WARNING, "WARNING", stdout, msg, ##__VA_ARGS__)
 #define LOG_ERROR(msg, ...)    log_str(ERROR, "ERROR", stderr, msg, ##__VA_ARGS__)
 #define LOG_FATAL(msg, ...)    log_str(FATAL, "FATAL", stderr, msg, ##__VA_ARGS__)
+
 #define YOBEMAG_EXIT(msg, ...) log_exit(__FILE__, __LINE__, msg, ##__VA_ARGS__)
 
 #pragma clang diagnostic pop

--- a/src/main.c
+++ b/src/main.c
@@ -8,30 +8,22 @@
 #include "cli.h"
 #include "log.h"
 
-static void teardown(void) {
-    fflush(stderr);
-    fflush(stdout);
-    // Both of these functions are "secured" against calling before initialization
-    SDL_Quit();
-    rom_destroy();
-}
-
 int main(int const argc, char **const argv) {
-    // First thing we do is register exit hook
-    atexit(&teardown);
-
     CLIArguments cli_args;
     cli_parse(&cli_args, argc, argv);
 
     log_set_lvl(cli_args.logging_level);
+    atexit(log_teardown);
 
     rom_init(cli_args.rom_path);
+    atexit(rom_destroy);
     LOG_INFO("Successfully initialized ROM");
 
     mmu_init();
     LOG_INFO("Successfully initialized MMU");
 
     lcd_init();
+    atexit(lcd_teardown);
     LOG_INFO("Successfully initialized LCD");
 
     cpu_init();
@@ -48,5 +40,5 @@ int main(int const argc, char **const argv) {
     }
     LOG_INFO("Total number of iterations: %d", iterations);
 
-    return EXIT_SUCCESS;
+    exit(EXIT_SUCCESS);
 }


### PR DESCRIPTION
Splits the registration of teardown functions, depending on which initialize functions have been successfully executed.