### PR TITLE
feat: add 8-bit OR A,n instruction with unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,7 @@ if (${TEST})
         test/alu_8bit_and_test.c
         test/alu_8bit_sub_test.c
         test/alu_8bit_sbc_test.c
+        test/alu_8bit_or_test.c
         test/cli_test.c
         test/rom_test.c
         test/mmu_test.c)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ if (${TEST})
     set(TEST_FILES
         test/fixtures/cpu_mmu.c
         test/common/util.c
+        test/common/alu.c
         test/8bit_lds_test.c
         test/alu_8bit_add_test.c
         test/alu_8bit_adc_test.c

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -241,6 +241,17 @@ static void optable_init(void) {
     instr_lookup[0xA7] = OPC_AND_A_A;
     instr_lookup[0xE6] = OPC_AND_A_d8;
 
+    // 8-bit ALU: OR A,n
+    instr_lookup[0xB0] = OPC_OR_A_B;
+    instr_lookup[0xB1] = OPC_OR_A_C;
+    instr_lookup[0xB2] = OPC_OR_A_D;
+    instr_lookup[0xB3] = OPC_OR_A_E;
+    instr_lookup[0xB4] = OPC_OR_A_H;
+    instr_lookup[0xB5] = OPC_OR_A_L;
+    instr_lookup[0xB6] = OPC_OR_A_HL;
+    instr_lookup[0xB7] = OPC_OR_A_A;
+    instr_lookup[0xF6] = OPC_OR_A_d8;
+
     // TODO: 0xA8
     // TODO: 0xA9
     // TODO: 0xAA
@@ -1165,6 +1176,70 @@ void OPC_AND_A_HL(void) {
 void OPC_AND_A_d8(void) {
     uint8_t immediate = mmu_get_byte(cpu.PC + 1);
     AND_A_n(immediate);
+    cpu.cycle_count += 8;
+    cpu.PC += 2;
+}
+
+static void OR_A_n(uint8_t n) {
+    uint8_t result = CPU_REG_A | n;
+
+    clear_flag_register(); // C, H, and N are implicitly cleared
+    set_flag(!result, Z_FLAG);
+
+    CPU_REG_A = result;
+}
+
+void OPC_OR_A_A(void) {
+    OR_A_n(CPU_REG_A);
+    cpu.cycle_count += 4;
+    ++cpu.PC;
+}
+
+void OPC_OR_A_B(void) {
+    OR_A_n(CPU_REG_B);
+    cpu.cycle_count += 4;
+    ++cpu.PC;
+}
+
+void OPC_OR_A_C(void) {
+    OR_A_n(CPU_REG_C);
+    cpu.cycle_count += 4;
+    ++cpu.PC;
+}
+
+void OPC_OR_A_D(void) {
+    OR_A_n(CPU_REG_D);
+    cpu.cycle_count += 4;
+    ++cpu.PC;
+}
+
+void OPC_OR_A_E(void) {
+    OR_A_n(CPU_REG_E);
+    cpu.cycle_count += 4;
+    ++cpu.PC;
+}
+
+void OPC_OR_A_H(void) {
+    OR_A_n(CPU_REG_H);
+    cpu.cycle_count += 4;
+    ++cpu.PC;
+}
+
+void OPC_OR_A_L(void) {
+    OR_A_n(CPU_REG_L);
+    cpu.cycle_count += 4;
+    ++cpu.PC;
+}
+
+void OPC_OR_A_HL(void) {
+    OR_A_n(mmu_get_byte(CPU_DREG_HL));
+    cpu.cycle_count += 8;
+    ++cpu.PC;
+}
+
+void OPC_OR_A_d8(void) {
+    uint8_t immediate = mmu_get_byte(cpu.PC + 1);
+    OR_A_n(immediate);
     cpu.cycle_count += 8;
     cpu.PC += 2;
 }

--- a/src/cpu.h
+++ b/src/cpu.h
@@ -396,4 +396,39 @@ void OPC_AND_A_HL(void);
  */
 void OPC_AND_A_d8(void);
 
+void OPC_OR_A_A(void);
+
+void OPC_OR_A_B(void);
+
+void OPC_OR_A_C(void);
+
+void OPC_OR_A_D(void);
+
+void OPC_OR_A_E(void);
+
+void OPC_OR_A_H(void);
+
+void OPC_OR_A_L(void);
+
+/**
+ * @brief First fetches a byte from the address `HL`,
+ * 		  then logical ands the fetched byte to A.
+ *
+ * @note This instruction requires the PC to be incremented by 1,
+ *       but takes 8 CPU cycles because of fetching a byte from memory.
+ */
+void OPC_OR_A_HL(void);
+
+/**
+ * @brief First fetches an immediate byte from PC + 1,
+ * 		  then logical ands the fetched byte to A.
+ *
+ * @warning PC cannot be incremented before this operation
+ * 			is completed since it reads the data from the
+ * 			opcode itself.
+ *
+ * @note This instruction requires the PC to be incremented by 2.
+ */
+void OPC_OR_A_d8(void);
+
 #endif // YOBEMAG_CPU_H

--- a/test/alu_8bit_or_test.c
+++ b/test/alu_8bit_or_test.c
@@ -1,0 +1,94 @@
+#include <criterion/criterion.h>
+#include <criterion/new/assert.h>
+#include <criterion/parameterized.h>
+
+#include "fixtures/cpu_mmu.h"
+#include "common/util.h"
+#include "common/alu.h"
+
+ParameterizedTestParameters(OR_A_n, OR_A_n_msb) {
+    static TestParams params[] = {
+        {0xB0, 128, 128, offsetof(CPU, BC), offsetof(DoubleWordReg, words.hi), 128, 1, 0b00000000},
+        {0xB1, 128, 128, offsetof(CPU, BC), offsetof(DoubleWordReg, words.lo), 128, 1, 0b00000000},
+        {0xB2, 128, 128, offsetof(CPU, DE), offsetof(DoubleWordReg, words.hi), 128, 1, 0b00000000},
+        {0xB3, 128, 128, offsetof(CPU, DE), offsetof(DoubleWordReg, words.lo), 128, 1, 0b00000000},
+        {0xB4, 128, 128, offsetof(CPU, HL), offsetof(DoubleWordReg, words.hi), 128, 1, 0b00000000},
+        {0xB5, 128, 128, offsetof(CPU, HL), offsetof(DoubleWordReg, words.lo), 128, 1, 0b00000000},
+        {0xB7, 128, 128, offsetof(CPU, AF), offsetof(DoubleWordReg, words.hi), 128, 1, 0b00000000},
+    };
+
+    return cr_make_param_array(TestParams, params, sizeof(params) / sizeof(TestParams));
+}
+
+ParameterizedTest(TestParams *params, OR_A_n, OR_A_n_msb, .init = cpu_mmu_setup, .fini = cpu_teardown) {
+    emulate_inst(params);
+}
+
+ParameterizedTestParameters(OR_A_n, OR_A_n_alternating) {
+    static TestParams params[] = {
+        {0xB0, 0b10101010, 0b01010101, offsetof(CPU, BC), offsetof(DoubleWordReg, words.hi), 255,        1,
+         0b00000000},
+        {0xB1, 0b10101010, 0b01010101, offsetof(CPU, BC), offsetof(DoubleWordReg, words.lo), 255,        1,
+         0b00000000},
+        {0xB2, 0b10101010, 0b01010101, offsetof(CPU, DE), offsetof(DoubleWordReg, words.hi), 255,        1,
+         0b00000000},
+        {0xB3, 0b10101010, 0b01010101, offsetof(CPU, DE), offsetof(DoubleWordReg, words.lo), 255,        1,
+         0b00000000},
+        {0xB4, 0b10101010, 0b01010101, offsetof(CPU, HL), offsetof(DoubleWordReg, words.hi), 255,        1,
+         0b00000000},
+        {0xB5, 0b10101010, 0b01010101, offsetof(CPU, HL), offsetof(DoubleWordReg, words.lo), 255,        1,
+         0b00000000},
+        {0xB7, 0b10101010, 0b01010101, offsetof(CPU, AF), offsetof(DoubleWordReg, words.hi), 0b01010101, 1,
+         0b00000000},
+    };
+
+    return cr_make_param_array(TestParams, params, sizeof(params) / sizeof(TestParams));
+}
+
+ParameterizedTest(TestParams *params, OR_A_n, OR_A_n_alternating, .init = cpu_mmu_setup,
+                  .fini = cpu_teardown) {
+    emulate_inst(params);
+}
+
+ParameterizedTestParameters(OR_A_n, OR_A_n_full) {
+    static TestParams params[] = {
+        {0xB0, 255, 255, offsetof(CPU, BC), offsetof(DoubleWordReg, words.hi), 255, 1, 0b00000000},
+        {0xB1, 255, 255, offsetof(CPU, BC), offsetof(DoubleWordReg, words.lo), 255, 1, 0b00000000},
+        {0xB2, 255, 255, offsetof(CPU, DE), offsetof(DoubleWordReg, words.hi), 255, 1, 0b00000000},
+        {0xB3, 255, 255, offsetof(CPU, DE), offsetof(DoubleWordReg, words.lo), 255, 1, 0b00000000},
+        {0xB4, 255, 255, offsetof(CPU, HL), offsetof(DoubleWordReg, words.hi), 255, 1, 0b00000000},
+        {0xB5, 255, 255, offsetof(CPU, HL), offsetof(DoubleWordReg, words.lo), 255, 1, 0b00000000},
+        {0xB7, 255, 255, offsetof(CPU, AF), offsetof(DoubleWordReg, words.hi), 255, 1, 0b00000000},
+    };
+
+    return cr_make_param_array(TestParams, params, sizeof(params) / sizeof(TestParams));
+}
+
+ParameterizedTest(TestParams *params, OR_A_n, OR_A_n_full, .init = cpu_mmu_setup, .fini = cpu_teardown) {
+    emulate_inst(params);
+}
+
+ParameterizedTestParameters(OR_A_n, AND_A_HL_and_d8) {
+    static SpecialTestParams params[] = {
+        {0xB6, 255, 255, 255, 0b00000000, true },
+        {0xB6, 8,   8,   8,   0b00000000, true },
+        {0xB6, 128, 128, 128, 0b00000000, true },
+        {0xB6, 254, 1,   255, 0b00000000, true },
+        {0xB6, 0,   0,   0,   0b10000000, true },
+        {0xB6, 128, 129, 129, 0b00000000, true },
+
+        {0xF6, 255, 255, 255, 0b00000000, false},
+        {0xF6, 8,   8,   8,   0b00000000, false},
+        {0xF6, 128, 128, 128, 0b00000000, false},
+        {0xF6, 254, 1,   255, 0b00000000, false},
+        {0xF6, 0,   0,   0,   0b10000000, false},
+        {0xF6, 128, 129, 129, 0b00000000, false},
+    };
+
+    return cr_make_param_array(SpecialTestParams, params, sizeof(params) / sizeof(SpecialTestParams));
+}
+
+ParameterizedTest(SpecialTestParams *params, OR_A_n, AND_A_HL_and_d8, .init = cpu_mmu_setup,
+                  .fini = cpu_teardown) {
+    emulate_HL_d8_inst(params);
+}

--- a/test/common/alu.c
+++ b/test/common/alu.c
@@ -1,0 +1,68 @@
+#include <criterion/criterion.h>
+#include <criterion/new/assert.h>
+
+#include "../common/util.h"
+#include "cpu.h"
+#include "mmu.h"
+#include "alu.h"
+
+void emulate_inst(TestParams const *const params) {
+    // setup cpu
+    uint16_t address = (random() % (MEM_SIZE - ROM_LIMIT)) + ROM_LIMIT;
+    cpu.PC           = address;
+    CPU_REG_A        = params->lhs;
+
+    // write rhs to desired register
+    uint8_t *target_reg = get_cpu_reg(params->rhs_dreg_offset, params->rhs_reg_offset);
+    *target_reg         = params->rhs;
+
+    mmu_write_byte(address, params->opcode);
+
+    // do the actual emulation
+    cpu_step();
+
+    // check flag register
+    cr_expect(eq(u8, CPU_REG_F, params->F), "l: %d, r: %d, op: 0x%x", params->lhs, params->rhs,
+              params->opcode);
+
+    // check if value is correct
+    uint8_t actual = CPU_REG_A;
+    cr_expect(eq(u8, actual, params->expected), "l: %d, r: %d, op: 0x%x", params->lhs, params->rhs,
+              params->opcode);
+
+    // check if PC is updated correctly
+    cr_expect(eq(u8, cpu.PC, (address + params->address_increment)));
+}
+
+void emulate_HL_d8_inst(SpecialTestParams const *const params) {
+    uint8_t opcode             = params->opcode;
+    uint8_t A                  = params->lhs;
+    uint8_t value              = params->rhs;
+    uint16_t address           = (random() % (MEM_SIZE - ROM_LIMIT)) + ROM_LIMIT;
+    uint16_t address_increment = 1;
+
+    // setup cpu
+    cpu.PC    = address;
+    CPU_REG_A = A;
+    mmu_write_byte(address, opcode);
+    if (params->is_HL) {
+        uint16_t indirection_address = (random() % (MEM_SIZE - ROM_LIMIT)) + ROM_LIMIT;
+        CPU_DREG_HL                  = indirection_address;
+        mmu_write_byte(indirection_address, value);
+    } else {
+        mmu_write_byte(address + 1, value);
+        ++address_increment;
+    }
+
+    // do the actual emulation
+    cpu_step();
+
+    // check flag register
+    cr_expect(eq(u8, CPU_REG_F, params->F));
+
+    // check if value is correct
+    cr_expect(eq(u8, CPU_REG_A, params->expected));
+
+    // check if PC is updated correctly
+    cr_expect(eq(u8, cpu.PC, address + address_increment));
+}

--- a/test/common/alu.h
+++ b/test/common/alu.h
@@ -1,0 +1,29 @@
+#ifndef YOBEMAG_ALU_H
+#define YOBEMAG_ALU_H
+
+typedef struct TestParams {
+    uint8_t opcode;
+    uint8_t lhs;
+    uint8_t rhs;
+    size_t rhs_dreg_offset;
+    size_t rhs_reg_offset;
+    uint8_t expected;
+    int address_increment;
+    uint8_t F;
+} TestParams;
+
+typedef struct SpecialTestParams {
+    uint8_t opcode;
+    uint8_t lhs;
+    uint8_t rhs;
+    uint8_t expected;
+    uint8_t F;
+    bool is_HL;
+    bool uses_borrow;
+} SpecialTestParams;
+
+void emulate_inst(TestParams const *params);
+
+void emulate_HL_d8_inst(SpecialTestParams const *params);
+
+#endif // YOBEMAG_ALU_H


### PR DESCRIPTION
Add OR A,n instruction and unit tests. Advances progress on issue https://github.com/Benzammour/yobemag/issues/12.
Also unify test helper functions as far as possible, this addresses #43.