### PR TITLE
feat: add clang-tidy review action

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,1 @@
+Checks: '-*,performance-*,bugprone-*,mpi-*,misc-*,clang-analyzer-*,-clang-analyzer-cplusplus*,-clang-analyzer-valist.Uninitialized,-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling'

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -1,0 +1,19 @@
+name: Clang-tidy review
+on: [ pull_request ]
+
+jobs:
+  clang-tidy-review:
+    name: Clang-tidy review
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Do clang-tidy review
+        uses: ZedThree/clang-tidy-review@v0.10.0
+        id: review
+        with:
+          config_file: '.clang-tidy'
+          apt_packages: ninja-build, libsdl2-dev, libcriterion-dev
+          cmake_command: cmake -G Ninja -DCMAKE_BUILD_TYPE=release -DCMAKE_C_COMPILER=clang . -DCMAKE_EXPORT_COMPILE_COMMANDS=on

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -3,6 +3,7 @@ on: [ pull_request ]
 
 jobs:
   clang-tidy-review:
+    if: ${{ !github.event.pull_request.draft }}
     name: Clang-tidy review
     runs-on: ubuntu-latest
 
@@ -10,7 +11,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Do clang-tidy review
+      - name: Clang-tidy review
         uses: ZedThree/clang-tidy-review@v0.10.0
         id: review
         with:

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -1,5 +1,11 @@
 name: Clang-tidy review
-on: [ pull_request ]
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
 
 jobs:
   clang-tidy-review:

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -16,4 +16,4 @@ jobs:
         with:
           config_file: '.clang-tidy'
           apt_packages: libsdl2-dev, libcriterion-dev
-          cmake_command: cmake -DCMAKE_BUILD_TYPE=release -DCMAKE_C_COMPILER=clang . -DCMAKE_EXPORT_COMPILE_COMMANDS=on
+          cmake_command: cmake . -DCMAKE_EXPORT_COMPILE_COMMANDS=on

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -15,5 +15,5 @@ jobs:
         id: review
         with:
           config_file: '.clang-tidy'
-          apt_packages: ninja-build, libsdl2-dev, libcriterion-dev
-          cmake_command: cmake -G Ninja -DCMAKE_BUILD_TYPE=release -DCMAKE_C_COMPILER=clang . -DCMAKE_EXPORT_COMPILE_COMMANDS=on
+          apt_packages: libsdl2-dev, libcriterion-dev
+          cmake_command: cmake -DCMAKE_BUILD_TYPE=release -DCMAKE_C_COMPILER=clang . -DCMAKE_EXPORT_COMPILE_COMMANDS=on


### PR DESCRIPTION
This PR introduces strong static analysis by clang-tidy with the help of a plug-and-play GitHub action: https://github.com/marketplace/actions/clang-tidy-review

Technically, this PR extends #16.