### PR TITLE
fix: switch order of members in CPU struct

### DIFF
--- a/src/cpu.h
+++ b/src/cpu.h
@@ -27,8 +27,8 @@ typedef enum flag {
 
 typedef union DoubleWordReg {
     struct {
-        uint8_t hi; // A, B, D, H
         uint8_t lo; // F, C, E, L
+        uint8_t hi; // A, B, D, H
     } words;
     uint16_t dword;
 } DoubleWordReg;

--- a/test/alu_8bit_adc_test.c
+++ b/test/alu_8bit_adc_test.c
@@ -165,6 +165,10 @@ ParameterizedTestParameters(ADC_A_n, ADC_A_HL_and_d8_borrow_and_no_borrow) {
 
 ParameterizedTest(SpecialTestParams *params, ADC_A_n, ADC_A_HL_and_d8_borrow_and_no_borrow, .init = cpu_mmu_setup,
                   .fini = cpu_teardown) {
-    set_flag(params->uses_borrow, C_FLAG);
+    if (params->uses_borrow) {
+        set_flag(1, C_FLAG);
+    } else {
+        clear_flag(C_FLAG);
+    }
     emulate_HL_d8_instruction(params);
 }


### PR DESCRIPTION
This makes the order of the low and high byte compliant with little-endian systems.